### PR TITLE
Allow Float32 args in order to conform with CorrData restrictions

### DIFF
--- a/src/DTWDT.jl
+++ b/src/DTWDT.jl
@@ -7,13 +7,13 @@ using .DTWDTfunctions
 export dtwdt
 
 """
-    dtwdt(u0::Array{Float64,1}, u1::Array{Float64,1}, dt::Float64; dtwnorm::String="L2"
+    dtwdt(u0::Union{Array{Float32,1},Array{Float64,1}}, u1::Union{Array{Float32,1},Array{Float64,1}}, dt::Float64; dtwnorm::String="L2"
         maxlag::Int64=80, b::Int64=1, direction::Int64=1)
 
 returns minimum distance time lag and index in dist array, and dtw error between traces.
 
 # Arguments
-- `u0, u1::Array{Float64,1}`: Time series.
+- `u0, u1::Union{Array{Float32,1},Array{Float64,1}}`: Time series.
 - `dt::Float64`: time step (dt of u0 and u1 should be same)
 - `dtwnorm::String`: norm to calculate distance; effect on the unit of dtw error. (L2 or L1)
 -  Note: L2 is not squard, thus distance is calculated as (u1[i]-u0[j])^2
@@ -28,7 +28,7 @@ returns minimum distance time lag and index in dist array, and dtw error between
 - `dtwerror::Float64`: dtw error (distance) between two time series.
 
 """
-function dtwdt(u0::Array{Float64,1}, u1::Array{Float64,1}, dt::Float64;
+function dtwdt(u0::Union{Array{Float32,1},Array{Float64,1}}, u1::Union{Array{Float32,1},Array{Float64,1}}, dt::Float64;
     dtwnorm::String="L2",    #norm to calculate distance; effect on the unit of dtw error
     maxLag::Int64=80,         #number of maxLag id to search the distance
     b::Int64=1,               #b value to controll in distance calculation algorithm (see Mikesell et al. 2015)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -27,7 +27,7 @@ export test, computeErrorFunction, accumulateErrorFunction, backtrackDistanceFun
  Original by Di Yang
  Last modified by Dylan Mikesell (25 Feb. 2015)
 """
-function computeErrorFunction(u1::Array{Float64, 1}, u0::Array{Float64, 1}, nSample::Int, lag::Int; norm::String="L2")
+function computeErrorFunction(u1::Union{Array{Float32,1},Array{Float64,1}}, u0::Union{Array{Float32,1},Array{Float64,1}}, nSample::Int, lag::Int; norm::String="L2")
 
     if lag >= nSample
         error("computeErrorFunction:lagProblem ","lag must be smaller than nSample");


### PR DESCRIPTION
CorrData and FFTData structs from SeisNoise restrict array values to 32-bit floating point numbers. This pull request allows both FP32 and FP64 values to be used for DTW.